### PR TITLE
Update actions/cache to version 5

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ runs:
         rustup target add wasm32-wasip2
 
     - name: Cache wash CLI
-      uses: actions/cache@v5
+      uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # 5.0.2
       id: wash-cache
       with:
         path: |

--- a/action.yml
+++ b/action.yml
@@ -22,7 +22,7 @@ runs:
         rustup target add wasm32-wasip2
 
     - name: Cache wash CLI
-      uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # 4.3.0
+      uses: actions/cache@v5
       id: wash-cache
       with:
         path: |


### PR DESCRIPTION
Old actions/cache causes failures in https://github.com/cosmonic-labs/openapi2mcp/actions/runs/23011713834/job/66823817339?pr=73