### PR TITLE
fix(action): update for install script improvements and v2.0.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,4 +34,4 @@ jobs:
         id: test-action-with-version
         uses: ./
         with:
-          wash-version: "wash-v2.0.0-rc.8"
+          wash-version: "wash-v2.0.1"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,4 +34,4 @@ jobs:
         id: test-action-with-version
         uses: ./
         with:
-          wash-version: "wash-v2.0.1"
+          wash-version: "v2.0.1"

--- a/README.md
+++ b/README.md
@@ -6,8 +6,6 @@
 
 This action installs the [wash](https://github.com/wasmCloud/wasmCloud) CLI, a tool for developing and managing WebAssembly (Wasm) components with [wasmCloud](https://wasmcloud.com/).
 
-> **_NOTE:_** This action sets up the next version of `wash` which does not yet have a stable 2.0 release.
-
 ## Usage
 
 Add the following step to your workflow to install `wash`:
@@ -16,14 +14,14 @@ Add the following step to your workflow to install `wash`:
 - name: Setup wash CLI
   uses: wasmCloud/setup-wash-action@main
   with:
-    wash-version: wash-v2.0.0-rc.8 # Optional
+    wash-version: wash-v2.0.1 # Optional
 ```
 
 ### Inputs
 
-| Name         | Description                                                               | Default          |
-| ------------ | ------------------------------------------------------------------------- | ---------------- |
-| wash-version | The version of wash to install. Note this uses tags until 2.0 is released | wash-v2.0.0-rc.8 |
+| Name         | Description                                 | Default        |
+| ------------ | ------------------------------------------- | -------------- |
+| wash-version | The version of wash to install              | wash-v2.0.1    |
 
 ## Example Workflow
 
@@ -40,7 +38,7 @@ jobs:
    - name: Setup wash CLI
     uses: wasmCloud/setup-wash-action@main
     with:
-     wash-version: wash-v2.0.0-rc.8
+     wash-version: wash-v2.0.1
    - name: Check wash version
     run: wash --version
 ```

--- a/README.md
+++ b/README.md
@@ -14,14 +14,14 @@ Add the following step to your workflow to install `wash`:
 - name: Setup wash CLI
   uses: wasmCloud/setup-wash-action@main
   with:
-    wash-version: wash-v2.0.1 # Optional
+    wash-version: v2.0.1 # Optional
 ```
 
 ### Inputs
 
 | Name         | Description                                 | Default        |
 | ------------ | ------------------------------------------- | -------------- |
-| wash-version | The version of wash to install              | wash-v2.0.1    |
+| wash-version | The version of wash to install              | v2.0.1    |
 
 ## Example Workflow
 
@@ -38,7 +38,7 @@ jobs:
    - name: Setup wash CLI
     uses: wasmCloud/setup-wash-action@main
     with:
-     wash-version: wash-v2.0.1
+     wash-version: v2.0.1
    - name: Check wash version
     run: wash --version
 ```

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ Add the following step to your workflow to install `wash`:
 
 ### Inputs
 
-| Name         | Description                                 | Default        |
-| ------------ | ------------------------------------------- | -------------- |
-| wash-version | The version of wash to install              | v2.0.1    |
+| Name         | Description                    | Default |
+| ------------ | ------------------------------ | ------- |
+| wash-version | The version of wash to install | v2.0.1  |
 
 ## Example Workflow
 

--- a/action.yml
+++ b/action.yml
@@ -11,7 +11,7 @@ inputs:
   wash-version:
     description: "The version of wash to install (default: latest), Examples: wash-v2.0.0-rc.8, latest, 0.51, 0.51.1, ^0.51, ~0.51"
     required: false
-    default: "wash-v2.0.0-rc.8"
+    default: "wash-v2.0.1"
 
 runs:
   using: "composite"

--- a/action.yml
+++ b/action.yml
@@ -9,9 +9,9 @@ branding:
 # Define your inputs here.
 inputs:
   wash-version:
-    description: "The version of wash to install (default: latest), Examples: wash-v2.0.0-rc.8, latest, 0.51, 0.51.1, ^0.51, ~0.51"
+    description: "The version of wash to install (default: latest), Examples: v2.0.1, wash-v2.0.0-rc.8, latest, 0.51, 0.51.1, ^0.51, ~0.51"
     required: false
-    default: "wash-v2.0.1"
+    default: "v2.0.1"
 
 runs:
   using: "composite"

--- a/action.yml
+++ b/action.yml
@@ -34,23 +34,12 @@ runs:
       if: steps.wash-cache.outputs.cache-hit != 'true' && runner.os != 'Windows'
       env:
         GITHUB_TOKEN: ${{ github.token }}
+        WASH_VERSION: ${{ inputs.wash-version }}
+        INSTALL_DIR: ${{ runner.tool_cache }}/wash/${{ inputs.wash-version }}
       run: |
         set -euo pipefail
-
-        wash_version="${{ inputs.wash-version }}"
-        wash_cache_dir="${RUNNER_TOOL_CACHE}/wash/${wash_version}"
-
-        echo "Installing wash ${wash_version}"
-
-        # Install wash using the official install script with verification
-        export WASH_VERSION="${wash_version}"
+        echo "Installing wash ${WASH_VERSION}"
         curl -sSL https://wasmcloud.com/sh | bash -s -- -v
-
-        # Add to tool cache
-        mkdir -p "${wash_cache_dir}"
-        cp ./wash "${wash_cache_dir}/wash"
-        chmod +x "${wash_cache_dir}/wash"
-
         echo "wash installed and cached successfully"
 
     - name: Install wash CLI (Windows)
@@ -58,23 +47,13 @@ runs:
       if: steps.wash-cache.outputs.cache-hit != 'true' && runner.os == 'Windows'
       env:
         GITHUB_TOKEN: ${{ github.token }}
+        WASH_VERSION: ${{ inputs.wash-version }}
+        INSTALL_DIR: ${{ runner.tool_cache }}/wash/${{ inputs.wash-version }}
       run: |
         $ErrorActionPreference = 'Stop'
-
-        $wash_version = "${{ inputs.wash-version }}"
-        $wash_cache_dir = "$env:RUNNER_TOOL_CACHE\wash\$wash_version"
-
-        Write-Host "Installing wash $wash_version"
-
-        # Install wash using the official PowerShell install script with verification
-        $env:WASH_VERSION = $wash_version
+        Write-Host "Installing wash $env:WASH_VERSION"
         $installScript = Invoke-WebRequest -Uri "https://wasmcloud.com/ps1" -UseBasicParsing
         Invoke-Expression "& { $($installScript.Content) } -Verify"
-
-        # Add to tool cache
-        New-Item -ItemType Directory -Force -Path $wash_cache_dir | Out-Null
-        Copy-Item -Path ".\wash.exe" -Destination "$wash_cache_dir\wash.exe"
-
         Write-Host "wash installed and cached successfully"
 
     - name: Add wash to PATH


### PR DESCRIPTION
Updates the action to work with the improved install scripts and bumps the default wash version to v2.0.1. Depends on wasmCloud/wasmCloud#5006.

## What changed

**Default version:** Bumped to `v2.0.1`.

**Install step simplification:** The install scripts now default to `~/.wash/bin` instead of the current working directory. The action sets `INSTALL_DIR` directly to the tool cache path via environment variable, so the binary lands in the right place immediately. This removes the previous pattern of installing to `cwd` and then copying the binary into the cache:

```diff
- export WASH_VERSION="${wash_version}"
- curl -sSL https://wasmcloud.com/sh | bash -s -- -v
- mkdir -p "${wash_cache_dir}"
- cp ./wash "${wash_cache_dir}/wash"
- chmod +x "${wash_cache_dir}/wash"
+ # INSTALL_DIR and WASH_VERSION set via env:
+ curl -sSL https://wasmcloud.com/sh | bash -s -- -v
```

Profile patching is automatically skipped in CI (`$CI=true` is set by GitHub Actions), so no `--no-modify-path` flag is needed.